### PR TITLE
feat: Role based user permissions

### DIFF
--- a/models/user.ts
+++ b/models/user.ts
@@ -9,7 +9,7 @@ export const User: ListConfig<Lists.User.TypeInfo<any>, any> = list({
   access: {
     operation: {
       query: ({ session }) => isSignedIn({ session }),
-      create: ({ session }) => permissions.isAdminLike({ session }), 
+      create: ({ session }) => permissions.isAdminLike({ session }),
       update: ({ session }) =>
         permissions.isAdminLike({ session }) || permissions.isStudent({ session }),
       delete: ({ session }) => permissions.isAdminLike({ session }),
@@ -48,7 +48,7 @@ export const User: ListConfig<Lists.User.TypeInfo<any>, any> = list({
       defaultValue: "Student",
       validation: { isRequired: true },
     }),
-    isAdmin: checkbox({ defaultValue: true }), 
+    isAdmin: checkbox({ defaultValue: true }),
     createdAt: timestamp({
       defaultValue: { kind: "now" },
     }),
@@ -59,4 +59,3 @@ export const User: ListConfig<Lists.User.TypeInfo<any>, any> = list({
     }),
   },
 });
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@keystone-6/fields-document": "^7.0.0",
         "@prisma/debug": "^5.3.1",
         "@prisma/generator-helper": "^5.3.1",
+        "all": "^0.0.0",
         "dotenv": "^16.3.1",
         "fs-extra": "^11.2.0",
         "keystone": "^4.2.1",
@@ -6785,6 +6786,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/all": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/all/-/all-0.0.0.tgz",
+      "integrity": "sha512-0oKlfNVv2d+d7c1gwjGspzgbwot47PGQ4b3v1ccx4mR8l9P/Y6E6Dr/yE8lNT63EcAKEbHo6UG3odDpC/NQcKw==",
+      "license": "MIT"
     },
     "node_modules/amdefine": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@keystone-6/fields-document": "^7.0.0",
     "@prisma/debug": "^5.3.1",
     "@prisma/generator-helper": "^5.3.1",
+    "all": "^0.0.0",
     "dotenv": "^16.3.1",
     "fs-extra": "^11.2.0",
     "keystone": "^4.2.1",

--- a/utils/access.ts
+++ b/utils/access.ts
@@ -1,0 +1,18 @@
+//access.ts
+type Session = {
+  data: {
+    role?: string;
+    id: string;
+  };
+};
+
+export const isSignedIn = ({ session }: { session?: Session }) => !!session;
+
+export const permissions = {
+  isStudent: ({ session }: { session?: Session }) => session?.data.role === 'Student',
+  isProjectMentor: ({ session }: { session?: Session }) => session?.data.role === 'Project Mentor',
+  isLeadMentor: ({ session }: { session?: Session }) => session?.data.role === 'Lead Mentor',
+  isExternalPartner: ({ session }: { session?: Session }) => session?.data.role === 'External Partner',
+  isAdminLike: ({ session }: { session?: Session }) =>
+    session?.data.role === 'Lead Mentor' || session?.data.role === 'Project Mentor',
+};

--- a/utils/access.ts
+++ b/utils/access.ts
@@ -9,10 +9,11 @@ type Session = {
 export const isSignedIn = ({ session }: { session?: Session }) => !!session;
 
 export const permissions = {
-  isStudent: ({ session }: { session?: Session }) => session?.data.role === 'Student',
-  isProjectMentor: ({ session }: { session?: Session }) => session?.data.role === 'Project Mentor',
-  isLeadMentor: ({ session }: { session?: Session }) => session?.data.role === 'Lead Mentor',
-  isExternalPartner: ({ session }: { session?: Session }) => session?.data.role === 'External Partner',
+  isStudent: ({ session }: { session?: Session }) => session?.data.role === "Student",
+  isProjectMentor: ({ session }: { session?: Session }) => session?.data.role === "Project Mentor",
+  isLeadMentor: ({ session }: { session?: Session }) => session?.data.role === "Lead Mentor",
+  isExternalPartner: ({ session }: { session?: Session }) =>
+    session?.data.role === "External Partner",
   isAdminLike: ({ session }: { session?: Session }) =>
-    session?.data.role === 'Lead Mentor' || session?.data.role === 'Project Mentor',
+    session?.data.role === "Lead Mentor" || session?.data.role === "Project Mentor",
 };

--- a/utils/values.ts
+++ b/utils/values.ts
@@ -3,5 +3,5 @@ export const UserRoleValues = [
   "Project Mentor",
   "Lead Mentor",
   "Student",
-  //possible 5th element 
+  //possible 5th element
 ] as const;

--- a/utils/values.ts
+++ b/utils/values.ts
@@ -1,8 +1,7 @@
 export const UserRoleValues = [
-  "Partner",
-  "Mentor",
+  "External Partner",
+  "Project Mentor",
   "Lead Mentor",
-  "Designer",
-  "Coordinator",
   "Student",
+  //possible 5th element 
 ] as const;


### PR DESCRIPTION
## Role based User permissions
 Implemented basic role-based CRUD permissions for the User list using a shared access.ts utility. This helper checks whether a user is signed in and evaluates their role to determine what actions they’re allowed to perform (e.g., view/edit self, admin rights, read-only access for partners, etc.).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If there are changes to custom resolvers, I have added / updated automated tests
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
