### PR TITLE
Feature/ppc2 14/create milestones table

### DIFF
--- a/models/milestone.ts
+++ b/models/milestone.ts
@@ -54,12 +54,12 @@ export const Milestone: ListConfig<Lists.Milestone.TypeInfo<any>, any> = list({
   access: {
     // operation-level access: broad rules
     operation: {
-      query: ({ session }) => !!session,
-      create: ({ session }) => isAdmin(session) || isManager(session),
-      update: ({ session }) => !!session, // allow logged-in users, enforce per-item in item access
-      delete: ({ session }) => isAdmin(session),
+      query: ({ session }) => !!session, // allow logged-in users
+      create: ({ session }) => isAdmin(session) || isManager(session), // if admin or manager
+      update: ({ session }) => !!session, // allow logged-in users
+      delete: ({ session }) => isAdmin(session), // only if admin
     },
-    // item-level access: fine-grained per record
+    // item-level access:
     item: {
       update: ({ session, item }) => {
         if (!session) return false;


### PR DESCRIPTION
## Describe your changes
Adds more granular, role-based access controls to the Milestone model:

- Admins can create, update, and delete any milestone
- Managers can create milestones and update only milestones that are assigned to them
- Logged-in users can query milestones
- Individual records have access rules for update/delete at the item level 

This ensures tighter security while maintaining existing functionality.


## Issue ticket number and link
PPC2-14
https://tripleten-apiary.atlassian.net/browse/PPC2-14

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If there are changes to custom resolvers, I have added / updated automated tests
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
