### PR TITLE
feat(auth): add login and signup functionality to backend

### DIFF
--- a/config/passport.ts
+++ b/config/passport.ts
@@ -1,35 +1,144 @@
 import passport from "passport";
 import { Strategy as GoogleStrategy, Profile } from "passport-google-oauth20";
+import { Strategy as LocalStrategy } from "passport-local";
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
 import { env } from "./config";
 
-export function setupPassport() {
-  if (!env.googleClientId || !env.googleClientSecret) {
-    throw new Error("Missing Google OAuth credentials");
-    // skipping Google OAuth setup
-    // console.warn("Skipping Google OAuth setup");
-    // return;
-  }
+const prisma = new PrismaClient();
 
+export function setupPassport() {
+  // Local Strategy for email/password authentication
   passport.use(
-    new GoogleStrategy(
+    new LocalStrategy(
       {
-        clientID: env.googleClientId,
-        clientSecret: env.googleClientSecret,
-        callbackURL: "/auth/google/callback",
+        usernameField: "email",
+        passwordField: "password",
       },
-      (accessToken, refreshToken, profile, done) => {
-        // TODO: Replace with logic to find or create a user in your DB
-        return done(null, profile); // TEMP: use Google profile as-is
+      async (email, password, done) => {
+        try {
+          const user = await prisma.user.findUnique({
+            where: { email: email.toLowerCase() },
+            include: {
+              userPermissions: {
+                include: {
+                  permission: true,
+                },
+              },
+            },
+          });
+
+          if (!user) {
+            return done(null, false, { message: "Invalid email or password" });
+          }
+
+          const isValidPassword = await bcrypt.compare(password, user.password);
+          if (!isValidPassword) {
+            return done(null, false, { message: "Invalid email or password" });
+          }
+
+          if (!user.isActive) {
+            return done(null, false, { message: "Account is not active" });
+          }
+
+          // Update last login date
+          await prisma.user.update({
+            where: { id: user.id },
+            data: { lastLoginDate: new Date() },
+          });
+
+          return done(null, user);
+        } catch (error) {
+          return done(error);
+        }
       }
     )
   );
 
-  passport.serializeUser((user, done) => {
-    done(null, user);
+  // Google OAuth Strategy
+  if (env.googleClientId && env.googleClientSecret) {
+    passport.use(
+      new GoogleStrategy(
+        {
+          clientID: env.googleClientId,
+          clientSecret: env.googleClientSecret,
+          callbackURL: "/auth/google/callback",
+        },
+        async (accessToken, refreshToken, profile, done) => {
+          try {
+            const email = profile.emails?.[0]?.value?.toLowerCase();
+            if (!email) {
+              return done(new Error("No email found in Google profile"), null);
+            }
+
+            // Check if user already exists
+            let user = await prisma.user.findUnique({
+              where: { email },
+              include: {
+                userPermissions: {
+                  include: {
+                    permission: true,
+                  },
+                },
+              },
+            });
+
+            if (!user) {
+              // Create new user from Google profile
+              user = await prisma.user.create({
+                data: {
+                  email,
+                  name: profile.displayName || profile.name?.givenName || "User",
+                  password: await bcrypt.hash(Math.random().toString(36), 10), // Random password for OAuth users
+                  role: "Student", // Default role
+                  isActive: true,
+                  lastLoginDate: new Date(),
+                },
+                include: {
+                  userPermissions: {
+                    include: {
+                      permission: true,
+                    },
+                  },
+                },
+              });
+            } else {
+              // Update last login date
+              await prisma.user.update({
+                where: { id: user.id },
+                data: { lastLoginDate: new Date() },
+              });
+            }
+
+            return done(null, user);
+          } catch (error) {
+            return done(error, null);
+          }
+        }
+      )
+    );
+  }
+
+  passport.serializeUser((user: any, done) => {
+    done(null, user.id);
   });
 
-  passport.deserializeUser((obj: any, done) => {
-    done(null, obj);
+  passport.deserializeUser(async (id: string, done) => {
+    try {
+      const user = await prisma.user.findUnique({
+        where: { id },
+        include: {
+          userPermissions: {
+            include: {
+              permission: true,
+            },
+          },
+        },
+      });
+      done(null, user);
+    } catch (error) {
+      done(error, null);
+    }
   });
 }
 

--- a/keystone.ts
+++ b/keystone.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 import { config } from "@keystone-6/core";
 import { lists } from "./models";
+import express from "express";
 
 dotenv.config();
 
@@ -19,12 +20,21 @@ export default withAuth(
     server: {
       port: 8080,
       cors: {
-        origin: "*",
+        origin: [
+          "http://localhost:3000",
+          "http://localhost:5173",
+          "http://localhost:3001",
+        ],
         methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
         credentials: true,
+        allowedHeaders: ["Content-Type", "Authorization"],
       },
       extendExpressApp: (app, commonContext) => {
         setupPassport();
+
+        // Parse JSON and URL-encoded bodies for REST endpoints
+        app.use(express.json());
+        app.use(express.urlencoded({ extended: true }));
 
         app.use(
           expressSession({

--- a/models/milestone.ts
+++ b/models/milestone.ts
@@ -3,6 +3,12 @@ import type { ListConfig } from "@keystone-6/core";
 import type { Lists } from ".keystone/types";
 import { text, select, relationship, timestamp } from "@keystone-6/core/fields";
 
+// --------------------
+// Helper functions for role-based access
+// --------------------
+const isAdmin = (session: any) => session?.data?.isAdmin;
+const isManager = (session: any) => session?.data?.role === "Manager";
+
 export const Milestone: ListConfig<Lists.Milestone.TypeInfo<any>, any> = list({
   // --------------------
   // Fields
@@ -44,14 +50,27 @@ export const Milestone: ListConfig<Lists.Milestone.TypeInfo<any>, any> = list({
   },
 
   // --------------------
-  // Access
+  // Access - more granular, role-based
   // --------------------
   access: {
+    // operation-level access: broad rules
     operation: {
-      query: ({ session }) => !!session,
-      create: ({ session }) => !!session,
-      update: ({ session }) => !!session,
-      delete: ({ session }) => !!session,
+      query: ({ session }) => !!session, // allow logged-in users
+      create: ({ session }) => isAdmin(session) || isManager(session), // if admin or manager
+      update: ({ session }) => !!session, // allow logged-in users
+      delete: ({ session }) => isAdmin(session), // only if admin
+    },
+    // item-level access:
+    item: {
+      update: ({ session, item }) => {
+        if (!session) return false;
+        if (isAdmin(session)) return true;
+        if (isManager(session) && item.assignee === session.data.id) return true;
+        return false;
+      },
+      delete: ({ session, item }) => {
+        return isAdmin(session);
+      },
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,11 @@
         "@keystone-6/fields-document": "^7.0.0",
         "@prisma/debug": "^5.3.1",
         "@prisma/generator-helper": "^5.3.1",
+        "@types/bcryptjs": "^2.4.6",
+        "@types/passport-local": "^1.0.38",
         "all": "^0.0.0",
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^5.1.0",
         "express-session": "^1.18.1",
@@ -24,6 +28,7 @@
         "lodash": "^4.17.21",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
+        "passport-local": "^1.0.0",
         "typescript": "^4.9.5"
       },
       "devDependencies": {
@@ -6632,6 +6637,7 @@
       }
     },
     "node_modules/@types/bcryptjs": {
+<<<<<<< Updated upstream
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-3.0.0.tgz",
       "integrity": "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==",
@@ -6640,6 +6646,11 @@
       "dependencies": {
         "bcryptjs": "*"
       }
+=======
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ=="
+>>>>>>> Stashed changes
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.4",
@@ -6832,7 +6843,6 @@
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
       "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/express": "*"
@@ -6850,6 +6860,16 @@
         "@types/passport-oauth2": "*"
       }
     },
+    "node_modules/@types/passport-local": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.38.tgz",
+      "integrity": "sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
     "node_modules/@types/passport-oauth2": {
       "version": "1.4.17",
       "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.17.tgz",
@@ -6859,6 +6879,15 @@
       "dependencies": {
         "@types/express": "*",
         "@types/oauth": "*",
+        "@types/passport": "*"
+      }
+    },
+    "node_modules/@types/passport-strategy": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+      "dependencies": {
+        "@types/express": "*",
         "@types/passport": "*"
       }
     },
@@ -9512,7 +9541,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -17740,6 +17768,17 @@
       "license": "MIT",
       "dependencies": {
         "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==",
+      "dependencies": {
+        "passport-strategy": "1.x.x"
       },
       "engines": {
         "node": ">= 0.4.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "@keystone-6/fields-document": "^7.0.0",
     "@prisma/debug": "^5.3.1",
     "@prisma/generator-helper": "^5.3.1",
+    "@types/bcryptjs": "^2.4.6",
+    "@types/passport-local": "^1.0.38",
     "all": "^0.0.0",
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^5.1.0",
     "express-session": "^1.18.1",
@@ -29,6 +33,7 @@
     "lodash": "^4.17.21",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
+    "passport-local": "^1.0.0",
     "typescript": "^4.9.5"
   },
   "devDependencies": {

--- a/routes/authRoutes.ts
+++ b/routes/authRoutes.ts
@@ -1,9 +1,114 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
 import { passport } from "../config/passport";
 
 const router = Router();
+const prisma = new PrismaClient();
 
-// Redirect user to Google for authentication
+// Traditional email/password login
+router.post("/auth/login", (req, res, next) => {
+  passport.authenticate("local", (err: any, user: any, info: any) => {
+    if (err) {
+      return res.status(500).json({ error: "Authentication error", details: err.message });
+    }
+    if (!user) {
+      return res.status(401).json({ error: info?.message || "Authentication failed" });
+    }
+    
+    req.logIn(user, (err) => {
+      if (err) {
+        return res.status(500).json({ error: "Login error", details: err.message });
+      }
+      
+      // Return user data without password
+      const { password, ...userWithoutPassword } = user;
+      return res.json({ 
+        message: "Login successful", 
+        user: userWithoutPassword,
+        isAuthenticated: true 
+      });
+    });
+  })(req, res, next);
+});
+
+// User registration
+router.post("/auth/register", async (req: Request, res: Response) => {
+  try {
+    const { name, email, password, role = "Student" } = req.body;
+
+    if (!name || !email || !password) {
+      return res.status(400).json({ error: "Name, email, and password are required" });
+    }
+
+    if (password.length < 8) {
+      return res.status(400).json({ error: "Password must be at least 8 characters long" });
+    }
+
+    // Check if user already exists
+    const existingUser = await prisma.user.findUnique({
+      where: { email: email.toLowerCase() },
+    });
+
+    if (existingUser) {
+      return res.status(409).json({ error: "User with this email already exists" });
+    }
+
+    // Hash password
+    const hashedPassword = await bcrypt.hash(password, 12);
+
+    // Create user
+    const user = await prisma.user.create({
+      data: {
+        name,
+        email: email.toLowerCase(),
+        password: hashedPassword,
+        role,
+        isActive: true,
+        createdAt: new Date(),
+      },
+    });
+
+    // Remove password from response
+    const { password: _, ...userWithoutPassword } = user;
+
+    res.status(201).json({
+      message: "User created successfully",
+      user: userWithoutPassword,
+    });
+  } catch (error) {
+    console.error("Registration error:", error);
+    res.status(500).json({ error: "Failed to create user" });
+  }
+});
+
+// Logout
+router.post("/auth/logout", (req: Request, res: Response) => {
+  req.logout((err) => {
+    if (err) {
+      return res.status(500).json({ error: "Logout failed" });
+    }
+    req.session.destroy((err) => {
+      if (err) {
+        return res.status(500).json({ error: "Session destruction failed" });
+      }
+      res.clearCookie("connect.sid");
+      res.json({ message: "Logout successful" });
+    });
+  });
+});
+
+// Get current user
+router.get("/auth/me", (req: Request, res: Response) => {
+  if (req.isAuthenticated() && req.user) {
+    const { password, ...userWithoutPassword } = req.user as any;
+    res.json({ user: userWithoutPassword, isAuthenticated: true });
+  } else {
+    res.status(401).json({ error: "Not authenticated", isAuthenticated: false });
+  }
+});
+
+// Google OAuth routes
 router.get(
   "/auth/google",
   passport.authenticate("google", {
@@ -15,12 +120,12 @@ router.get(
 router.get(
   "/auth/google/callback",
   passport.authenticate("google", {
-    failureRedirect: "/login",
+    failureRedirect: `${process.env.FRONTEND_URL || "http://localhost:5173"}/login?error=oauth_failed`,
     session: true,
   }),
   (req, res) => {
-    // Success: redirect to dashboard or home
-    res.redirect("/");
+    // Success: redirect to frontend dashboard
+    res.redirect(`${process.env.FRONTEND_URL || "http://localhost:5173"}/dashboard`);
   }
 );
 

--- a/scripts/seed-permissions.ts
+++ b/scripts/seed-permissions.ts
@@ -1,0 +1,93 @@
+/**
+ * Permission Seeding Script
+ * 
+ * This script seeds the database with initial permissions and sets up
+ * 
+ * 
+ *  Testing Script for Permission System
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { PermissionValues } from '../utils/values';
+
+const prisma = new PrismaClient();
+
+const PERMISSION_DEFINITIONS = [
+  // User Management Permissions
+  { name: 'users:create', description: 'Create new users', category: 'users' },
+  { name: 'users:read', description: 'View user information', category: 'users' },
+  { name: 'users:update', description: 'Update user details', category: 'users' },
+  { name: 'users:delete', description: 'Delete users', category: 'users' },
+  { name: 'users:manage_roles', description: 'Assign roles and permissions to users', category: 'users' },
+  
+  // Project Management Permissions
+  { name: 'projects:create', description: 'Create new projects', category: 'projects' },
+  { name: 'projects:read', description: 'View project information', category: 'projects' },
+  { name: 'projects:update', description: 'Update project details', category: 'projects' },
+  { name: 'projects:delete', description: 'Delete projects', category: 'projects' },
+  { name: 'projects:assign_members', description: 'Manage project membership', category: 'projects' },
+  
+  // Milestone Permissions
+  { name: 'milestones:create', description: 'Create milestones', category: 'milestones' },
+  { name: 'milestones:read', description: 'View milestones', category: 'milestones' },
+  { name: 'milestones:update', description: 'Update milestones', category: 'milestones' },
+  { name: 'milestones:delete', description: 'Delete milestones', category: 'milestones' },
+  
+  // Activity Log Permissions
+  { name: 'activity_logs:read', description: 'View activity logs', category: 'activity_logs' },
+  { name: 'activity_logs:manage', description: 'Manage activity logs', category: 'activity_logs' },
+  
+  // System Administration
+  { name: 'system:admin', description: 'System administration access', category: 'system' },
+  { name: 'system:settings', description: 'System settings management', category: 'system' },
+];
+
+async function seedPermissions() {
+  console.log('🌱 Seeding permissions...');
+
+  try {
+    // Create permissions
+    for (const permission of PERMISSION_DEFINITIONS) {
+      await prisma.permission.upsert({
+        where: { name: permission.name },
+        update: {
+          description: permission.description,
+          category: permission.category,
+        },
+        create: {
+          name: permission.name,
+          description: permission.description,
+          category: permission.category,
+        },
+      });
+    }
+
+    console.log(`✅ Created/updated ${PERMISSION_DEFINITIONS.length} permissions`);
+
+    // Create a super admin user if none exists
+    const adminUser = await prisma.user.findFirst({
+      where: { role: 'Admin' },
+    });
+
+    if (!adminUser) {
+      console.log('⚠️  No admin user found. Please create an admin user manually or through the Keystone admin interface.');
+    } else {
+      console.log(`✅ Admin user exists: ${adminUser.email}`);
+    }
+
+    console.log('🎉 Permission seeding completed successfully!');
+    
+  } catch (error) {
+    console.error('❌ Error seeding permissions:', error);
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Run the seeding function
+if (require.main === module) {
+  seedPermissions();
+}
+
+export { seedPermissions };

--- a/simple-server.js
+++ b/simple-server.js
@@ -1,0 +1,181 @@
+const express = require('express');
+const cors = require('cors');
+const session = require('express-session');
+const passport = require('passport');
+const bcrypt = require('bcryptjs');
+const { PrismaClient } = require('@prisma/client');
+
+const app = express();
+const prisma = new PrismaClient();
+
+// Middleware
+app.use(cors({
+  origin: ['http://localhost:3000', 'http://localhost:3001', 'http://localhost:5173'],
+  credentials: true,
+}));
+
+app.use(express.json());
+app.use(session({
+  secret: 'test-secret-key',
+  resave: false,
+  saveUninitialized: false,
+  cookie: { secure: false } // Set to true if using HTTPS
+}));
+
+app.use(passport.initialize());
+app.use(passport.session());
+
+// Simple passport configuration
+passport.serializeUser((user, done) => {
+  done(null, user.id);
+});
+
+passport.deserializeUser(async (id, done) => {
+  try {
+    const user = await prisma.user.findUnique({ where: { id } });
+    done(null, user);
+  } catch (error) {
+    done(error, null);
+  }
+});
+
+// Routes
+app.get('/api/_root_health', (req, res) => {
+  res.send('ok-root');
+});
+
+// Registration
+app.post('/auth/register', async (req, res) => {
+  try {
+    const { name, email, password, role = 'Student' } = req.body;
+
+    if (!name || !email || !password) {
+      return res.status(400).json({ error: 'Name, email, and password are required' });
+    }
+
+    if (password.length < 8) {
+      return res.status(400).json({ error: 'Password must be at least 8 characters long' });
+    }
+
+    // Check if user already exists
+    const existingUser = await prisma.user.findUnique({
+      where: { email: email.toLowerCase() },
+    });
+
+    if (existingUser) {
+      return res.status(409).json({ error: 'User with this email already exists' });
+    }
+
+    // Hash password
+    const hashedPassword = await bcrypt.hash(password, 12);
+
+    // Create user
+    const user = await prisma.user.create({
+      data: {
+        name,
+        email: email.toLowerCase(),
+        password: hashedPassword,
+        role,
+        isActive: true,
+        createdAt: new Date(),
+      },
+    });
+
+    // Remove password from response
+    const { password: _, ...userWithoutPassword } = user;
+
+    res.status(201).json({
+      message: 'User created successfully',
+      user: userWithoutPassword,
+    });
+  } catch (error) {
+    console.error('Registration error:', error);
+    res.status(500).json({ error: 'Failed to create user' });
+  }
+});
+
+// Login
+app.post('/auth/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+
+    if (!email || !password) {
+      return res.status(400).json({ error: 'Email and password are required' });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { email: email.toLowerCase() },
+    });
+
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid email or password' });
+    }
+
+    const isValidPassword = await bcrypt.compare(password, user.password);
+    if (!isValidPassword) {
+      return res.status(401).json({ error: 'Invalid email or password' });
+    }
+
+    if (!user.isActive) {
+      return res.status(401).json({ error: 'Account is not active' });
+    }
+
+    // Update last login date
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { lastLoginDate: new Date() },
+    });
+
+    // Log the user in
+    req.login(user, (err) => {
+      if (err) {
+        return res.status(500).json({ error: 'Login error' });
+      }
+      
+      const { password: _, ...userWithoutPassword } = user;
+      return res.json({ 
+        message: 'Login successful', 
+        user: userWithoutPassword,
+        isAuthenticated: true 
+      });
+    });
+  } catch (error) {
+    console.error('Login error:', error);
+    res.status(500).json({ error: 'Login failed' });
+  }
+});
+
+// Get current user
+app.get('/auth/me', (req, res) => {
+  if (req.isAuthenticated() && req.user) {
+    const { password, ...userWithoutPassword } = req.user;
+    res.json({ user: userWithoutPassword, isAuthenticated: true });
+  } else {
+    res.status(401).json({ error: 'Not authenticated', isAuthenticated: false });
+  }
+});
+
+// Logout
+app.post('/auth/logout', (req, res) => {
+  req.logout((err) => {
+    if (err) {
+      return res.status(500).json({ error: 'Logout failed' });
+    }
+    req.session.destroy((err) => {
+      if (err) {
+        return res.status(500).json({ error: 'Session destruction failed' });
+      }
+      res.clearCookie('connect.sid');
+      res.json({ message: 'Logout successful' });
+    });
+  });
+});
+
+const PORT = 8080;
+app.listen(PORT, () => {
+  console.log(`🚀 Simple auth server running on http://localhost:${PORT}`);
+  console.log(`📊 Health check: http://localhost:${PORT}/api/_root_health`);
+});
+
+module.exports = app;
+


### PR DESCRIPTION
I have added full local email/password login and signup flows alongside Google OAuth. For signup, you now validate inputs, hash passwords with bcrypt, check for duplicates, create users with default roles, and return user data without the password. For login, you integrated a Passport LocalStrategy with Prisma lookups, bcrypt password checks, active-account verification, and automatic last-login updates.