### PR TITLE
fix: add missing SE (Software Engineering) program option

### DIFF
--- a/controllers/studentController.ts
+++ b/controllers/studentController.ts
@@ -6,6 +6,7 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const WAITLIST_SELECT =
   "id name email status notes program completedOn contactedBy { id } lastContactedOn hasVoucher";
 const MAP_UI_TO_DB: Record<string, string> = {
+  se: "software_engineering",
   "ai/ml": "ai_machine_learning",
   "ai automation": "ai_automation",
   "bi analytics": "business_intelligence_analytics",

--- a/models/waitListStudent.ts
+++ b/models/waitListStudent.ts
@@ -49,6 +49,7 @@ export const waitListStudent = list({
     }),
     program: select({
       options: [
+        { label: "SE", value: "software_engineering" },
         { label: "AI/ML", value: "ai_machine_learning" },
         { label: "AI Automation", value: "ai_automation" },
         { label: "BI Analytics", value: "business_intelligence_analytics" },


### PR DESCRIPTION
# Fix: Add missing SE (Software Engineering) program option

## Describe your changes

This PR fixes a critical bug where updating waitlist students with the "SE" (Software Engineering) program would fail with 400/500 errors.

### Changes Made:

**Backend - studentController.ts:**
- Added `se: "software_engineering"` to the `MAP_UI_TO_DB` mapping
- This allows the API to properly convert the frontend's "SE" value to the database format

**Backend - waitListStudent.ts model:**
- Added `{ label: "SE", value: "software_engineering" }` as the first option in the program select field
- This ensures Keystone validation accepts the software_engineering value

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to custom resolvers, I have added / updated automated tests
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
