### PR TITLE
Feature/fix invitation system

### DIFF
--- a/__tests__/invitations.test.ts
+++ b/__tests__/invitations.test.ts
@@ -196,14 +196,15 @@ describe("Invitations Route", () => {
       expect(response.text).toContain("Authentication required");
     });
 
-    it("should return 400 when expiresAt is missing", async () => {
+    it("should default expiresAt when it is missing", async () => {
       const invalidData = { ...validInvitationData };
       delete (invalidData as any).expiresAt;
 
       const response = await request(app).post("/project-123/invitations").send(invalidData);
 
-      expect(response.status).toBe(400);
-      expect(response.text).toContain("expiresAt");
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("expiresAt");
+      expect(Number.isNaN(Date.parse(response.body.expiresAt))).toBe(false);
     });
 
     it("should return 400 when expiresAt is invalid", async () => {
@@ -590,14 +591,15 @@ describe("Invitations Route", () => {
       expect(response.text).toContain("Authentication required");
     });
 
-    it("should return 400 when expiresAt is missing", async () => {
+    it("should default expiresAt when it is missing", async () => {
       const invalidData = { ...validTokenData };
       delete (invalidData as any).expiresAt;
 
       const response = await request(app).post("/project-123/invitationTokens").send(invalidData);
 
-      expect(response.status).toBe(400);
-      expect(response.text).toContain("expiresAt");
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("expiresAt");
+      expect(Number.isNaN(Date.parse(response.body.expiresAt))).toBe(false);
     });
   });
 

--- a/keystone.ts
+++ b/keystone.ts
@@ -52,6 +52,12 @@ export default withAuth(
         apiRouter.use("/invitations/analytics", createInvitationAnalyticsRouter(commonContext));
         apiRouter.use("/waitlist", createWaitlistRouter(commonContext));
 
+        // Test route to verify API router is working
+        apiRouter.use((req, _res, next) => {
+          console.log("🔥 /api hit:", req.method, req.originalUrl);
+          next();
+        });
+
         //Mount the /api router once
         app.use("/api", apiRouter);
 

--- a/routes/invitationsRoute.ts
+++ b/routes/invitationsRoute.ts
@@ -8,12 +8,13 @@ import type { Request } from "express";
 import { permissions } from "../utils/access";
 
 // Validation constants
-const ALLOWED_ROLES = ["Student", "Project Mentor", "Mentor", "Admin"] as const;
+const ALLOWED_ROLES = ["Student", "Project Mentor", "Lead Mentor", "External Partner"] as const;
 const MAX_USES_MIN = 1;
 const MAX_USES_MAX = 100;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_NAME_LENGTH = 255;
 const MAX_NOTES_LENGTH = 1000;
+const DEFAULT_INVITE_EXPIRY = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
 
 // Security constants
 const TOKEN_BYTE_SIZE = 32; // Size in bytes for crypto.randomBytes
@@ -74,13 +75,20 @@ export function createInvitationsRouter(commonContext: Context) {
     const { roleToGrant = "Student", expiresAt, maxUses = 1, notes = "" } = body ?? {};
 
     // Validate expiresAt
-    if (!expiresAt || isNaN(Date.parse(expiresAt))) {
-      return res.status(400).json(
-        createErrorResponse("VALIDATION_ERROR", "expiresAt (ISO) is required and must be valid", {
-          field: "expiresAt",
-          value: expiresAt,
-        })
-      );
+    let expirationDate: Date;
+    if (!expiresAt) {
+      // compute default expiration (7 days from now)
+      expirationDate = new Date(Date.now() + DEFAULT_INVITE_EXPIRY);
+    } else {
+      expirationDate = new Date(expiresAt);
+      if (Number.isNaN(expirationDate.getTime())) {
+        return res.status(400).json(
+          createErrorResponse("VALIDATION_ERROR", "expiresAt must be a valid date", {
+            field: "expiresAt",
+            value: expiresAt,
+          })
+        );
+      }
     }
 
     // Validate roleToGrant
@@ -127,7 +135,7 @@ export function createInvitationsRouter(commonContext: Context) {
           tokenHash,
           project: { connect: { id: req.params.projectId } },
           roleToGrant,
-          expiresAt: new Date(expiresAt).toISOString(),
+          expiresAt: expirationDate.toISOString(),
           maxUses: maxUsesNum,
           createdBy: { connect: { id: session.id } },
           notes,
@@ -201,17 +209,17 @@ export function createInvitationsRouter(commonContext: Context) {
       return res.status(400).json(
         createErrorResponse("VALIDATION_ERROR", "Invalid email format", {
           field: "recipientEmail",
-          value: recipientEmail,
+          value: finalRecipientEmail,
         })
       );
     }
 
     // Validate recipientName length
-    if (recipientName && recipientName.length > MAX_NAME_LENGTH) {
+    if (finalRecipientName && finalRecipientName.length > MAX_NAME_LENGTH) {
       return res.status(400).json(
         createErrorResponse("VALIDATION_ERROR", "Recipient name too long", {
           field: "recipientName",
-          currentLength: recipientName.length,
+          currentLength: finalRecipientName.length,
           maxLength: MAX_NAME_LENGTH,
         })
       );
@@ -229,13 +237,20 @@ export function createInvitationsRouter(commonContext: Context) {
     }
 
     // Validate expiresAt
-    if (!expiresAt || isNaN(Date.parse(expiresAt))) {
-      return res.status(400).json(
-        createErrorResponse("VALIDATION_ERROR", "expiresAt is required and must be valid", {
-          field: "expiresAt",
-          value: expiresAt,
-        })
-      );
+    let expirationDate: Date;
+    if (!expiresAt) {
+      // compute default expiration (7 days from now)
+      expirationDate = new Date(Date.now() + DEFAULT_INVITE_EXPIRY);
+    } else {
+      expirationDate = new Date(expiresAt);
+      if (Number.isNaN(expirationDate.getTime())) {
+        return res.status(400).json(
+          createErrorResponse("VALIDATION_ERROR", "expiresAt must be a valid date", {
+            field: "expiresAt",
+            value: expiresAt,
+          })
+        );
+      }
     }
 
     // Validate maxUses
@@ -270,9 +285,6 @@ export function createInvitationsRouter(commonContext: Context) {
         })
       );
     }
-
-    const expirationDate = new Date(expiresAt);
-    const currentDate = new Date();
 
     // Handle both existing user invitations and email-based invitations
     let student = null;

--- a/routes/invitationsRoute.ts
+++ b/routes/invitationsRoute.ts
@@ -153,8 +153,19 @@ export function createInvitationsRouter(commonContext: Context) {
     }
   });
 
+  // Test route to verify router is working
+  router.get("/ping", (req, res) => {
+    res.json({ ok: true, route: "projects invitations router" });
+  });
+
   // Create or update invitation and send email
   router.post("/:projectId/invitations", async (req, res) => {
+    console.log("✅ HIT POST /:projectId/invitations", {
+      originalUrl: req.originalUrl,
+      params: req.params,
+      body: req.body,
+    });
+
     const context = await commonContext.withRequest(req, res);
     const session = (context.session as any)?.data;
 

--- a/routes/invitationsRoute.ts
+++ b/routes/invitationsRoute.ts
@@ -67,7 +67,7 @@ export function createInvitationsRouter(commonContext: Context) {
     }
 
     // Check authorization - only admins can create invitations
-    if (!permissions.isAdminLike({ session })) {
+    if (!permissions.isAdminLike({ session: context.session as any })) {
       return res.status(403).json(createErrorResponse("FORBIDDEN", "Admin access required"));
     }
 
@@ -153,19 +153,8 @@ export function createInvitationsRouter(commonContext: Context) {
     }
   });
 
-  // Test route to verify router is working
-  router.get("/ping", (req, res) => {
-    res.json({ ok: true, route: "projects invitations router" });
-  });
-
   // Create or update invitation and send email
   router.post("/:projectId/invitations", async (req, res) => {
-    console.log("✅ HIT POST /:projectId/invitations", {
-      originalUrl: req.originalUrl,
-      params: req.params,
-      body: req.body,
-    });
-
     const context = await commonContext.withRequest(req, res);
     const session = (context.session as any)?.data;
 
@@ -178,6 +167,8 @@ export function createInvitationsRouter(commonContext: Context) {
       recipientEmail?: string;
       recipientName?: string;
       token?: string;
+      name?: string;
+      email?: string;
     };
 
     // Check authentication
@@ -186,7 +177,7 @@ export function createInvitationsRouter(commonContext: Context) {
     }
 
     // Check authorization - only admins can create invitations
-    if (!permissions.isAdminLike({ session })) {
+    if (!permissions.isAdminLike({ session: context.session as any })) {
       return res.status(403).json(createErrorResponse("FORBIDDEN", "Admin access required"));
     }
 
@@ -198,10 +189,15 @@ export function createInvitationsRouter(commonContext: Context) {
       studentId = "",
       recipientEmail = "",
       recipientName = "",
+      email = "",
+      name = "",
     } = body;
 
+    const finalRecipientEmail = recipientEmail || email;
+    const finalRecipientName = recipientName || name;
+
     // Validate recipientEmail
-    if (recipientEmail && !isValidEmail(recipientEmail)) {
+    if (finalRecipientEmail && !isValidEmail(finalRecipientEmail)) {
       return res.status(400).json(
         createErrorResponse("VALIDATION_ERROR", "Invalid email format", {
           field: "recipientEmail",

--- a/utils/access.ts
+++ b/utils/access.ts
@@ -6,16 +6,23 @@ type Session = {
   };
 };
 
-export const isSignedIn = ({ session }: { session?: Session }) => !!session;
+export const isSignedIn = ({ session }: { session?: Session }) => !!session?.data?.id;
+
+const normalizeRole = (role?: string) => (role ?? "").trim().toLowerCase();
 
 // Granular helpers
 export const permissions = {
-  isStudent: ({ session }: { session?: Session }) => session?.data.role === "Student",
-  isProjectMentor: ({ session }: { session?: Session }) => session?.data.role === "Project Mentor",
-  isLeadMentor: ({ session }: { session?: Session }) => session?.data.role === "Lead Mentor",
+  isStudent: ({ session }: { session?: Session }) =>
+    normalizeRole(session?.data.role) === "student",
+  isProjectMentor: ({ session }: { session?: Session }) =>
+    normalizeRole(session?.data.role) === "project mentor",
+  isLeadMentor: ({ session }: { session?: Session }) =>
+    normalizeRole(session?.data.role) === "lead mentor",
   isExternalPartner: ({ session }: { session?: Session }) =>
-    session?.data.role === "External Partner",
-  isAdminLike: ({ session }: { session?: Session }) =>
-    ["Admin", "Lead Mentor", "Project Mentor"].includes(session?.data.role ?? ""),
+    normalizeRole(session?.data.role) === "external partner",
+  isAdminLike: ({ session }: { session?: Session }) => {
+    const role = normalizeRole(session?.data?.role);
+    return ["admin", "lead mentor", "project mentor"].includes(role);
+  },
   isProjectMember: ({ session }: { session?: Session }) => session?.data.project === "",
 };


### PR DESCRIPTION
## BE changes for ticket: fix: Align invitation roles, fix admin auth checkbox, add default expiry
- Mismatch field names: FE sent name, email & BE expected recipientName, recipientEmail
  - Added fallback mapping to invitationsRoute.ts: finalRecipientName, finalRecipientEmail allows handling without breaking FE
- Admin Authorization fix: permissions.isAdminLike was receiving session.data instead of the full session object
   - Updated route to pass session: context.session to permissions.isAdminLike
-   Missing expiresAt: /invitations + /invitationToken requires expiresAt
     - BE validation combined missing + invalid values throwing 400 error code
     - Implemented defaut expiration if expiresAt is missing and always use expirationDate.toISOString(), applied logic to both routes
- Keystone validation failure (500): keystone rejected InvitationToken.roleToGrant due to mismatch roles 
  - Updated ALLOWED_ROLES (invitationsRoute.ts) to match schema options (invitationToken.ts) + removed unsupported roles
- Automated test failed due to new expiresAt behavior
  - Old behavior: missing expiresAt return 400 / new behavior: missing expiresAt return 200 with default expiration
  - Updated invitations.test.ts to expect 200 when expiresAt is missing & includes default expiration date (DEFAULT_INVITE_EXPIRY)    


## Notes
- Frontend PR updates role dropdown to match backend schema.


## PR checklist
- [ x ] I have performed a self-review of my code
- [ x ] If there are changes to custom resolvers, I have added / updated automated tests
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ N/A ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings