### PR TITLE
Fix/admin auth checkbox

### DIFF
--- a/__tests__/invitations.test.ts
+++ b/__tests__/invitations.test.ts
@@ -125,7 +125,7 @@ describe("Invitations Route", () => {
 
   describe("POST /:projectId/invitations", () => {
     const validInvitationData = {
-      roleToGrant: "student",
+      roleToGrant: "Student",
       expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
       maxUses: 1,
       notes: "Test invitation",
@@ -161,28 +161,43 @@ describe("Invitations Route", () => {
       expect(response.body.inviteLink).toMatch(/accept-invitation\?token=.*&invitationId=/);
     });
 
-    it("should normalize role to proper case", async () => {
+    it("should accept role with different casing by normalizing it", async () => {
+      mockFindMany.mockResolvedValueOnce([]); // No existing ProjectInvitation
+      mockCreateOne.mockResolvedValueOnce({
+        ...mockProjectInvitation,
+        id: "new-invitation-123",
+      });
+      mockCreateOne.mockResolvedValueOnce({
+        ...mockInvitationToken,
+        id: "new-token-123",
+      });
+      const response = await request(app)
+        .post("/project-123/invitations")
+        .send({
+          ...validInvitationData,
+          roleToGrant: "sTuDeNt", // Mixed case should normalize to "Student"
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("inviteLink");
+      expect(response.body.message).toContain("New invitation token created");
+    });
+
+    it("should reject invalid role", async () => {
       // First findMany checks for existing ProjectInvitation (none found)
       mockFindMany.mockResolvedValueOnce([]);
-      mockCreateOne.mockResolvedValueOnce(mockProjectInvitation);
-      mockCreateOne.mockResolvedValueOnce(mockInvitationToken);
 
       const response = await request(app)
         .post("/project-123/invitations")
         .send({
           ...validInvitationData,
-          roleToGrant: "student", // lowercase
+          roleToGrant: "UnknownRole", // invalid role
         });
 
-      expect(response.status).toBe(200);
-      // Verify the token was created with capitalized role
-      expect(mockCreateOne).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            roleToGrant: "Student", // Should be capitalized
-          }),
-        })
-      );
+      expect(response.status).toBe(400);
+      expect(response.text).toContain("Invalid role");
+      // Verify the token was not created due to invalid role
+      expect(mockCreateOne).not.toHaveBeenCalled();
     });
 
     it("should return 401 when user is not authenticated", async () => {

--- a/routes/invitationsRoute.ts
+++ b/routes/invitationsRoute.ts
@@ -67,7 +67,7 @@ export function createInvitationsRouter(commonContext: Context) {
     }
 
     // Check authorization - only admins can create invitations
-    if (!permissions.isAdminLike({ session })) {
+    if (!permissions.isAdminLike({ session: context.session })) {
       return res.status(403).json(createErrorResponse("FORBIDDEN", "Admin access required"));
     }
 

--- a/routes/invitationsRoute.ts
+++ b/routes/invitationsRoute.ts
@@ -1,4 +1,3 @@
-import { Router } from "express";
 import crypto from "crypto";
 import * as bcrypt from "bcryptjs";
 import type { Context } from ".keystone/types";
@@ -83,12 +82,19 @@ export function createInvitationsRouter(commonContext: Context) {
       );
     }
 
-    // Validate roleToGrant
-    if (!isValidRole(roleToGrant)) {
+    // Normalize role
+    const normalizedRole = String(roleToGrant)
+      .split(" ")
+      .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(" ");
+
+    // Validate role
+    if (!isValidRole(normalizedRole)) {
       return res.status(400).json(
         createErrorResponse("VALIDATION_ERROR", "Invalid role", {
           field: "roleToGrant",
           value: roleToGrant,
+          normalizedValue: normalizedRole,
           allowedValues: ALLOWED_ROLES,
         })
       );
@@ -126,7 +132,7 @@ export function createInvitationsRouter(commonContext: Context) {
         data: {
           tokenHash,
           project: { connect: { id: req.params.projectId } },
-          roleToGrant,
+          roleToGrant: normalizedRole,
           expiresAt: new Date(expiresAt).toISOString(),
           maxUses: maxUsesNum,
           createdBy: { connect: { id: session.id } },
@@ -137,11 +143,14 @@ export function createInvitationsRouter(commonContext: Context) {
       const frontendUrl = process.env.FRONTEND_URL || DEFAULT_FRONTEND_URL;
       const inviteLink = `${frontendUrl}/accept-invitation?token=${rawToken}&invitationId=${created.id}`;
 
+      // Always echo the original expiration string
+      const responseExpires = new Date(expiresAt).toISOString();
+
       res.json({
         id: created.id,
         token: rawToken, // Raw token (send this via email)
         inviteLink, // Followable link
-        expiresAt: created.expiresAt,
+        expiresAt: responseExpires,
       });
     } catch (err: any) {
       console.error(err);
@@ -175,6 +184,7 @@ export function createInvitationsRouter(commonContext: Context) {
     }
 
     // Check authorization - only admins can create invitations
+    // Pass the full Keystone session (not the unwrapped .data) so isAdminLike can access session.data.role
     if (!permissions.isAdminLike({ session: context.session })) {
       return res.status(403).json(createErrorResponse("FORBIDDEN", "Admin access required"));
     }
@@ -244,14 +254,19 @@ export function createInvitationsRouter(commonContext: Context) {
       );
     }
 
+    // Normalize role
+    const normalizedRole = String(roleToGrant)
+      .split(" ")
+      .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(" ");
+
     // Validate role — frontend sends exact values matching InvitationToken model options
-    if (!isValidRole(roleToGrant)) {
+    if (!isValidRole(normalizedRole)) {
       return res.status(400).json(
         createErrorResponse("VALIDATION_ERROR", "Invalid role", {
           field: "roleToGrant",
-
           value: roleToGrant,
-
+          normalizedValue: normalizedRole,
           allowedValues: ALLOWED_ROLES,
         })
       );
@@ -317,7 +332,7 @@ export function createInvitationsRouter(commonContext: Context) {
         data: {
           tokenHash,
           project: { connect: { id: projectInvitation.id } }, // Connect to ProjectInvitation
-          roleToGrant: roleToGrant,
+          roleToGrant: normalizedRole,
           expiresAt: expirationDate.toISOString(),
           maxUses: maxUsesNum,
           notes,

--- a/routes/invitationsRoute.ts
+++ b/routes/invitationsRoute.ts
@@ -8,7 +8,7 @@ import type { Request } from "express";
 import { permissions } from "../utils/access";
 
 // Validation constants
-const ALLOWED_ROLES = ["Student", "Project Mentor", "Mentor", "Admin"] as const;
+const ALLOWED_ROLES = ["Student", "Project Mentor", "Lead Mentor", "External Partner"] as const;
 const MAX_USES_MIN = 1;
 const MAX_USES_MAX = 100;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -67,6 +67,7 @@ export function createInvitationsRouter(commonContext: Context) {
     }
 
     // Check authorization - only admins can create invitations
+    // Note: Pass full keystone object so isAdminLike can check both role and isAdmin boolean
     if (!permissions.isAdminLike({ session: context.session })) {
       return res.status(403).json(createErrorResponse("FORBIDDEN", "Admin access required"));
     }
@@ -175,7 +176,7 @@ export function createInvitationsRouter(commonContext: Context) {
     }
 
     // Check authorization - only admins can create invitations
-    if (!permissions.isAdminLike({ session })) {
+    if (!permissions.isAdminLike({ session: context.session })) {
       return res.status(403).json(createErrorResponse("FORBIDDEN", "Admin access required"));
     }
 

--- a/routes/invitationsRoute.ts
+++ b/routes/invitationsRoute.ts
@@ -67,7 +67,6 @@ export function createInvitationsRouter(commonContext: Context) {
     }
 
     // Check authorization - only admins can create invitations
-    // Note: Pass full keystone object so isAdminLike can check both role and isAdmin boolean
     if (!permissions.isAdminLike({ session: context.session })) {
       return res.status(403).json(createErrorResponse("FORBIDDEN", "Admin access required"));
     }
@@ -245,21 +244,14 @@ export function createInvitationsRouter(commonContext: Context) {
       );
     }
 
-    // Normalize roleToGrant to match the expected format
-    // For single word roles like "student", capitalize first letter
-    // For multi-word roles like "project mentor", capitalize each word
-    const normalizedRole = roleToGrant
-      .split(" ")
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-      .join(" ");
-
-    // Validate role after normalization
-    if (!isValidRole(normalizedRole)) {
+    // Validate role — frontend sends exact values matching InvitationToken model options
+    if (!isValidRole(roleToGrant)) {
       return res.status(400).json(
         createErrorResponse("VALIDATION_ERROR", "Invalid role", {
           field: "roleToGrant",
+
           value: roleToGrant,
-          normalizedValue: normalizedRole,
+
           allowedValues: ALLOWED_ROLES,
         })
       );
@@ -325,7 +317,7 @@ export function createInvitationsRouter(commonContext: Context) {
         data: {
           tokenHash,
           project: { connect: { id: projectInvitation.id } }, // Connect to ProjectInvitation
-          roleToGrant: normalizedRole,
+          roleToGrant: roleToGrant,
           expiresAt: expirationDate.toISOString(),
           maxUses: maxUsesNum,
           notes,

--- a/utils/access.ts
+++ b/utils/access.ts
@@ -3,6 +3,7 @@ type Session = {
     role?: string;
     id: string;
     project?: string; // (slug or name you store on the User)
+    isAdmin?: boolean;
   };
 };
 
@@ -16,6 +17,7 @@ export const permissions = {
   isExternalPartner: ({ session }: { session?: Session }) =>
     session?.data.role === "External Partner",
   isAdminLike: ({ session }: { session?: Session }) =>
+    session?.data?.isAdmin === true ||
     ["Admin", "Lead Mentor", "Project Mentor"].includes(session?.data.role ?? ""),
   isProjectMember: ({ session }: { session?: Session }) => session?.data.project === "",
 };

--- a/utils/access.ts
+++ b/utils/access.ts
@@ -11,13 +11,13 @@ export const isSignedIn = ({ session }: { session?: Session }) => !!session;
 
 // Granular helpers
 export const permissions = {
-  isStudent: ({ session }: { session?: Session }) => session?.data.role === "Student",
-  isProjectMentor: ({ session }: { session?: Session }) => session?.data.role === "Project Mentor",
-  isLeadMentor: ({ session }: { session?: Session }) => session?.data.role === "Lead Mentor",
+  isStudent: ({ session }: { session?: Session }) => session?.data?.role === "Student",
+  isProjectMentor: ({ session }: { session?: Session }) => session?.data?.role === "Project Mentor",
+  isLeadMentor: ({ session }: { session?: Session }) => session?.data?.role === "Lead Mentor",
   isExternalPartner: ({ session }: { session?: Session }) =>
-    session?.data.role === "External Partner",
+    session?.data?.role === "External Partner",
   isAdminLike: ({ session }: { session?: Session }) =>
     session?.data?.isAdmin === true ||
     ["Admin", "Lead Mentor", "Project Mentor"].includes(session?.data.role ?? ""),
-  isProjectMember: ({ session }: { session?: Session }) => session?.data.project === "",
+  isProjectMember: ({ session }: { session?: Session }) => session?.data?.project === "",
 };


### PR DESCRIPTION
## Fix Invitations auth + role validation:
- isAdmin missing from session’s data: added isAdmin?: Boolean; to the session.data type
- Previously access was based on only roles: updated isAdminLike to include session?.data?isAdmin === true ||, now access is granted if isAdmin is strictly true or the user has one of the admin-like roles
- Update ALLOWED_ROLES in invitationsRoute to match expected roleToGrant values
- Pass the full Keystone session (not the unwrapped .data) so isAdminLike can access session.data.role
- Restored backend role normalization to safely handle casing differences before validation
- Validated normalizedRole and used it when creating invitation tokens
- Ensured consistent role handling across both /invitations and /invitationToken endpoints
## Expiry handling
- Implemented default 30 day expiration logic to sendUserInvitation in api.ts and included expiresAt in the request payload
## Fix Test
- Updated validInvitationData to use allowed role constants
- Aligned tests with validation and normalization behaviors
- Adjusted response to reflect 400 response for invalid role values
- Ensured token hashing and invitation creation logic still pass all tests
